### PR TITLE
Fixed issue with numpy, yt links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run the AI cover generation pipeline, run the following command.
 python src/main.py -yt YOUTUBE_LINK -dir MODEL_DIR_NAME -p PITCH_CHANGE
 ```
 
-- Replace YOUTUBE_LINK with any link to a song on YouTube.
+- Replace YOUTUBE_LINK with any link to a song on YouTube. Link should be enclosed in double quotes for Windows and single quotes for Unix-like systems
 - Replace MODEL_DIR_NAME with the name of the folder in the [rvc_models](rvc_models) directory containing your `.pth` and `.index` files.
 - Replace PITCH_CHANGE with 0 for no change in pitch to the AI vocals. Generally use 12 for male to female conversions or -12 for vice-versa.
 

--- a/src/main.py
+++ b/src/main.py
@@ -135,6 +135,9 @@ def song_cover_pipeline(yt_link, voice_model, pitch_change):
     with open(os.path.join(mdxnet_models_dir, 'model_data.json')) as infile:
         mdx_model_params = json.load(infile)
 
+    if '&' in yt_link:
+        yt_link = yt_link.split('&')[0]
+
     match = re.search(r"v=([^&]+)", yt_link)
     song_id = match.group(1)
     song_dir = os.path.join(output_dir, song_id)

--- a/src/mdx.py
+++ b/src/mdx.py
@@ -237,6 +237,11 @@ class MDX:
 
 def run_mdx(model_params, output_dir, model_path, filename, exclude_main=False, exclude_inversion=False, suffix=None, invert_suffix=None, denoise=False, keep_orig=True, m_threads=2):
     device = torch.device('cuda:0') if torch.cuda.is_available() else torch.device('cpu')
+
+    device_properties = torch.cuda.get_device_properties(device)
+    vram_gb = device_properties.total_memory / 1024**3
+    m_threads = 1 if vram_gb < 8 else 2
+
     model_hash = MDX.get_hash(model_path)
     mp = model_params.get(model_hash)
     model = MDXModel(

--- a/src/vc_infer_pipeline.py
+++ b/src/vc_infer_pipeline.py
@@ -146,7 +146,7 @@ class VC(object):
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(int)
         return f0_coarse, f0bak  # 1-0
 
     def vc(


### PR DESCRIPTION
## Fixed deprication of np.int to just int, since we are using numpy>1.20

` File "\AICoverGen\src\vc_infer_pipeline.py", line 149, in get_f0
    f0_coarse = np.rint(f0_mel).astype(np.int)
  File "\lib\site-packages\numpy\__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
'np.int' was a deprecated alias for the builtin 'int'. To avoid this error in existing code, use 'int' by itself.
The aliases was originally deprecated in NumPy 1.20`

## Fixed links from playlist, the main issue is that program tries to download every track from that playlist
#4 

## For weak gpu`s
I've added small validation of how much vram do you have based on my experience 6GB of vram was not enough.
So for gpus that have less than 8gb I made the program to change number of m_threads from `2` to `1`
(out of memory issue)

## README.md change. 
I added that users shoud use double quotes " for windows systems and single quotes ' for unix-like system for yt link.
Because of `&` it was sending the program running into background

Tested every solution. I hope this will help.